### PR TITLE
Corrected event bus rule limit, fixed typo

### DIFF
--- a/doc_source/content-filtering-with-event-patterns.md
+++ b/doc_source/content-filtering-with-event-patterns.md
@@ -42,7 +42,7 @@ Anything\-but matching matches anything except what's provided in the rule\.
 
 You can use `anything-but` with strings and numeric values, including lists that contain only strings, or only numbers\.
 
-The following shows single `anyting-but` matching, first with strings and then with numbers\.
+The following shows single `anything-but` matching, first with strings and then with numbers\.
 
 ```
 {

--- a/doc_source/create-event-bus.md
+++ b/doc_source/create-event-bus.md
@@ -8,7 +8,7 @@ You can create two types of additional event buses in your account:
   For more information, see [Receiving Events from an SaaS Partner](create-partner-event-bus.md)\.
 + *Custom event buses*, which can receive events from your custom applications and services\.
 
-  Each event bus in your account can have up to 100 EventBridge rules associated with it, so if your account has many rules, you might want to create custom event buses to associate with some of the rules for your custom application events\. Another reason to create custom event buses is to apply different permissions to different event buses\. When you set permissions on an event bus, you can specify which other accounts or entire organizations can send events to the event bus\.
+  Each event bus in your account can have up to 300 EventBridge rules associated with it, so if your account has many rules, you might want to create custom event buses to associate with some of the rules for your custom application events\. Another reason to create custom event buses is to apply different permissions to different event buses\. When you set permissions on an event bus, you can specify which other accounts or entire organizations can send events to the event bus\.
 
 ## Creating a Custom Event Bus<a name="create-custom-event-bus"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

The "Create Event Bus" page incorrectly states that event buses can have up to 100 rules associated with it while the quota page states "300 per event bus", so I changed the value 100 to 300 in that page. I also noticed a very small typo where 'anything-but' was misspelled.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
