### PR TITLE
Correct typo in event patterns page

### DIFF
--- a/doc_source/eb-event-patterns.md
+++ b/doc_source/eb-event-patterns.md
@@ -157,7 +157,7 @@ Consider the following Amazon Macie Classic event, which is truncated\.
       "rule-arn": "arn:aws:macie:us-east-1:123456789012:trigger/trigger_id",
       "alert-type": "basic",
       "created-at": "2017-01-02 19:54:00.644000",
-      "description": "Alerting on failed enumeration of large number of bucket policie
+      "description": "Alerting on failed enumeration of large number of bucket policies"
       "risk": 8
     },
 "created-at": "2017-04-18T00:21:12.059000",

--- a/doc_source/eb-event-patterns.md
+++ b/doc_source/eb-event-patterns.md
@@ -157,7 +157,7 @@ Consider the following Amazon Macie Classic event, which is truncated\.
       "rule-arn": "arn:aws:macie:us-east-1:123456789012:trigger/trigger_id",
       "alert-type": "basic",
       "created-at": "2017-01-02 19:54:00.644000",
-      "description": "Alerting on failed enumeration of large number of bucket policies"
+      "description": "Alerting on failed enumeration of large number of bucket policies",
       "risk": 8
     },
 "created-at": "2017-04-18T00:21:12.059000",


### PR DESCRIPTION
In the Amazon EventBridge event patterns user guide, example events and event patterns page, correct a typo in the given example Amazon Macie Classic event.

*Description of changes:*
in `doc_source/eb-event-patterns.md` change `policie` ➪ `policies",`

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
