### PR TITLE
add extra required details to encrypted sqs queue

### DIFF
--- a/doc_source/eb-troubleshooting.md
+++ b/doc_source/eb-troubleshooting.md
@@ -156,20 +156,20 @@ An infinite loop can quickly cause higher than expected charges\. We recommend t
 
 ## My events are not delivered to the target Amazon SQS queue<a name="eb-sqs-encrypted"></a>
 
-If your Amazon SQS queue is encrypted, you must include the following section in your KMS key policy\.
+If your Amazon SQS queue is encrypted, you must must create a customer managed KMS key and add include the following permission section in your KMS key policy. For more information, see [Configureing AWS KMS permissions](https://docs.aws.amazon.com/AWSSimpleQueueService/latest/SQSDeveloperGuide/sqs-key-management.html#sqs-what-permissions-for-sse)
 
 ```
 {
-                "Sid": "Allow CWE to use the key",
-                "Effect": "Allow",
-                "Principal": {
-                                "Service": "events.amazonaws.com"
-                },
-                "Action": [
-                                "kms:Decrypt",
-                                "kms:GenerateDataKey"
-                ],
-                "Resource": "*"
+    "Sid": "Allow EventBridge to use the key",
+    "Effect": "Allow",
+    "Principal": {
+        "Service": "events.amazonaws.com"
+    },
+    "Action": [
+        "kms:Decrypt",
+        "kms:GenerateDataKey"
+    ],
+    "Resource": "*"
 }
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
Steps required to send to an encrypted SQS were missing details about having to create a customer-managed KMS key.

*Description of changes:*
This change adds the missing required steps along with some minor JSON formatting fixes

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
