### PR TITLE
Restrict the example permission that allows another accounts to send events into the default bus

### DIFF
--- a/doc_source/eb-event-bus-perms.md
+++ b/doc_source/eb-event-bus-perms.md
@@ -121,7 +121,7 @@ The following example policy grants the account 111122223333 permission to use a
         "Sid": "sid1",
         "Effect": "Allow",
         "Principal": {"AWS":"arn:aws:iam::111112222333:root"},
-        "Action": "events:*",
+        "Action": "events:PutEvents",
         "Resource": "arn:aws:events:us-east-1:123456789012:event-bus/default"
         }
     ]


### PR DESCRIPTION
*Description of changes:*

Hello maintainer-san, 👋🏽 

I'd like to report that it will be more consistent if you change the Action of the example permission like this.
You can find other examples below (written in [the same page](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-event-bus-perms.html#eb-event-bus-example-policy-cross-account)) specifying only `events:PutEvents`.

- Example policy: Send events to a custom bus in a different account
- Example policy: Send events only from a specific rule to the bus in a different Region

Best Regards,

---

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
