### PR TITLE
adding missing line and comma

### DIFF
--- a/doc_source/eb-transform-target-input.md
+++ b/doc_source/eb-transform-target-input.md
@@ -51,7 +51,8 @@ When defining a rule in the console, select the **Input Transformer** option und
 {
   "timestamp" : "$.time",
   "instance" : "$.detail.instance-id", 
-  "state" : "$.detail.state"
+  "state" : "$.detail.state",
+  "resource" : "$.resources[0]"
 }
 ```
 


### PR DESCRIPTION
The [web page](https://docs.aws.amazon.com/eventbridge/latest/userguide/eb-transform-target-input.html) shows a line that isn't in the docs. I'm adding this line (along with the missing comma currently in the web page) to source.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
