### PR TITLE
EC2 Create Snapshot to EBS, inline with the UI

### DIFF
--- a/doc_source/eb-targets.md
+++ b/doc_source/eb-targets.md
@@ -15,7 +15,7 @@ You can configure the following targets for events in the EventBridge console:
 + CloudWatch log group
 + CodeBuild project
 + CodePipeline
-+ EC2 `CreateSnapshot` API call
++ EBS `CreateSnapshot` API call
 + EC2 Image Builder
 + EC2 `RebootInstances` API call
 + EC2 `StopInstances` API call


### PR DESCRIPTION
*Description of changes:*

<img width="759" alt="image" src="https://user-images.githubusercontent.com/5158554/211178147-6c021463-1785-4167-8c2a-d87f17ba337a.png">

In the AWS Console UI, it displays the target as EBS Create Snapshot instead of EC2 Create Snapshot which is listed in the documentation. This change corrects it.