### PR TITLE
eb-pipes-dynamodb: Amend Batch size sentence when target is SQS

### DIFF
--- a/doc_source/eb-pipes-dynamodb.md
+++ b/doc_source/eb-pipes-dynamodb.md
@@ -118,7 +118,7 @@ If you’re unsure of the exact well\-scoped permissions required to access the 
 
 1. \(Optional\) For **Additional setting \- optional**, do the following:
 
-   1. For **Batch size \- optional**, enter a maximum number of records for each batch\. The default value is 100\.
+   1. For **Batch size \- optional**, enter a maximum number of records for each batch\. The default value is 100\. If the target is  default value is Amazon SQS the maximum value is 10\. 
 
    1. For **Batch window \- optional**, enter a maximum number of seconds to gather records before proceeding\.
 

--- a/doc_source/eb-pipes-dynamodb.md
+++ b/doc_source/eb-pipes-dynamodb.md
@@ -118,7 +118,7 @@ If you’re unsure of the exact well\-scoped permissions required to access the 
 
 1. \(Optional\) For **Additional setting \- optional**, do the following:
 
-   1. For **Batch size \- optional**, enter a maximum number of records for each batch\. The default value is 100\. If the target is  default value is Amazon SQS the maximum value is 10\. 
+   1. For **Batch size \- optional**, enter a maximum number of records for each batch\. The default value is 100\. If, for example, the target is Amazon SQS, then the maximum value is 10\. 
 
    1. For **Batch window \- optional**, enter a maximum number of seconds to gather records before proceeding\.
 


### PR DESCRIPTION
*Description of changes:*
In the Additional setting for Amazon DynamoDB stream as a source, I have changed the Batch size sentence to say that the default value is 10 when the target is Amazon SQS

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
